### PR TITLE
Support Vagrant 1.9.3

### DIFF
--- a/providers/vagrant/Vagrantfile
+++ b/providers/vagrant/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant.configure("2") do |config|
   config.vm.define "master" do |node|
     node.vm.hostname = "master"
     node.vm.network :private_network, ip: "192.168.33.10"
-    node.vm.network "forwarded_port", guest: 8080, host: 8080
+    node.vm.network "forwarded_port", guest: 8080, host: 8080, host_ip: "127.0.0.1"
 
     node.vm.synced_folder "../../../rancher-salt", "/home/vagrant/rancher-salt"
 


### PR DESCRIPTION
Use 127.0.0.1 for host IP when unset and 0.0.0.0 is not available